### PR TITLE
Add leaflet dependency to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,5 +13,8 @@
     "README.md",
     "package.json",
     "bower.json"
-  ]
+  ],
+  "dependencies": {
+    "leaflet": "~0.7.3"
+  }
 }


### PR DESCRIPTION
Missing dependency? I just chose the most recent Leaflet here; not sure if you have any opinions about it, but this lets me consume the library without a bower override to enforce load order.