### PR TITLE
Fix up eventing to avoid leaks

### DIFF
--- a/src/DynamicLabel/DynamicLabel.js
+++ b/src/DynamicLabel/DynamicLabel.js
@@ -46,9 +46,10 @@ function DynamicLabel(map, pbfSource, options) {
   this.activeTiles = {};
 
   this._determineActiveTiles();
+  this.map.on('move', this._determineActiveTiles, this);
   var self = this;
-  this.map.on('move', function() {
-    self._determineActiveTiles();
+  pbfSource.on('remove', function() {
+    self.map.off('move', self._determineActiveTiles, self);
   });
 
 }

--- a/src/MVTFeature.js
+++ b/src/MVTFeature.js
@@ -41,10 +41,10 @@ function MVTFeature(mvtLayer, vtf, ctx, id, style) {
   //Add to the collection
   this.addTileFeature(vtf, ctx);
 
-  this.map.on('zoomend', this.removeLabel, this);
+  this.map.on('zoomend', this._zoomend, this);
   var self = this;
   mvtLayer.on('remove', function() {
-    self.map.off('zoomend', self.removeLabel, self);
+    self.map.off('zoomend', self._zoomend, self);
   });
 
   if (style && style.dynamicLabel && typeof style.dynamicLabel === 'function') {
@@ -172,8 +172,6 @@ MVTFeature.prototype.addTileFeature = function(vtf, ctx) {
   var zoom = this.map.getZoom();
 
   if(ctx.zoom != zoom) return;
-
-  this.clearTileFeatures(zoom); //TODO: This iterates thru all tiles every time a new tile is added.  Figure out a better way to do this.
 
   this.tiles[ctx.id] = {
     ctx: ctx,
@@ -393,6 +391,11 @@ MVTFeature.prototype.removeLabel = function() {
   if (!this.staticLabel) return;
   this.staticLabel.remove();
   this.staticLabel = null;
+};
+
+MVTFeature.prototype._zoomend = function() {
+  this.removeLabel();
+  this.clearTileFeatures(this.map.getZoom());
 };
 
 /**

--- a/src/MVTFeature.js
+++ b/src/MVTFeature.js
@@ -12,7 +12,10 @@ function MVTFeature(mvtLayer, vtf, ctx, id, style) {
 
   // Apply all of the properties of vtf to this object.
   for (var key in vtf) {
-    this[key] = vtf[key];
+    // Ignore private fields.
+    if (key.charAt(0) !== '_') {
+      this[key] = vtf[key];
+    }
   }
 
   this.mvtLayer = mvtLayer;

--- a/src/MVTFeature.js
+++ b/src/MVTFeature.js
@@ -38,16 +38,17 @@ function MVTFeature(mvtLayer, vtf, ctx, id, style) {
   //Add to the collection
   this.addTileFeature(vtf, ctx);
 
+  this.map.on('zoomend', this.removeLabel, this);
   var self = this;
-  this.map.on('zoomend', function() {
-    self.staticLabel = null;
+  mvtLayer.on('remove', function() {
+    self.map.off('zoomend', self.removeLabel, self);
   });
 
   if (style && style.dynamicLabel && typeof style.dynamicLabel === 'function') {
     this.dynamicLabel = this.mvtSource.dynamicLabel.createFeature(this);
   }
 
-  ajax(self);
+  ajax(this);
 }
 
 

--- a/src/MVTLayer.js
+++ b/src/MVTLayer.js
@@ -166,7 +166,6 @@ module.exports = L.TileLayer.Canvas.extend({
     var features = vtl.parsedFeatures;
     for (var i = 0, len = features.length; i < len; i++) {
       var vtf = features[i]; //vector tile feature
-      vtf.layer = vtl;
 
       /**
        * Apply filter on feature if there is one. Defined in the options object

--- a/src/MVTLayer.js
+++ b/src/MVTLayer.js
@@ -71,15 +71,14 @@ module.exports = L.TileLayer.Canvas.extend({
   },
 
   onAdd: function(map) {
-    var self = this;
-    self.map = map;
+    this.map = map;
     L.TileLayer.Canvas.prototype.onAdd.call(this, map);
-    map.on('layerremove', function(e) {
-      // we only want to do stuff when the layerremove event is on this layer
-      if (e.layer._leaflet_id === self._leaflet_id) {
-        removeLabels(self);
-      }
-    });
+  },
+
+  onRemove: function(map) {
+    this.fire('remove');
+    removeLabels(this);
+    L.TileLayer.Canvas.prototype.onRemove.call(this, map);
   },
 
   drawTile: function(canvas, tilePoint, zoom) {

--- a/src/MVTSource.js
+++ b/src/MVTSource.js
@@ -108,31 +108,23 @@ module.exports = L.TileLayer.MVTSource = L.TileLayer.Canvas.extend({
   },
 
   onAdd: function(map) {
-    var self = this;
-    self.map = map;
+    this.map = map;
     L.TileLayer.Canvas.prototype.onAdd.call(this, map);
 
-    var mapOnClickCallback = function(e) {
-      self._onClick(e);
-    };
+    map.on('click', this._onClick, this);
 
-    map.on('click', mapOnClickCallback);
-
-    map.on("layerremove", function(e) {
-      // check to see if the layer removed is this one
-      // call a method to remove the child layers (the ones that actually have something drawn on them).
-      if (e.layer._leaflet_id === self._leaflet_id && e.layer.removeChildLayers) {
-        e.layer.removeChildLayers(map);
-        map.off('click', mapOnClickCallback);
-      }
-    });
-
-    self.addChildLayers(map);
+    this.addChildLayers(map);
 
     if (typeof DynamicLabel === 'function' ) {
       this.dynamicLabel = new DynamicLabel(map, this, {});
     }
+  },
 
+  onRemove: function(map) {
+    this.fire('remove');
+    this.removeChildLayers(map);
+    map.off('click', this._onClick, this);
+    L.TileLayer.Canvas.prototype.onRemove.call(this, map);
   },
 
   drawTile: function(canvas, tilePoint, zoom) {

--- a/src/MVTSource.js
+++ b/src/MVTSource.js
@@ -69,9 +69,6 @@ module.exports = L.TileLayer.MVTSource = L.TileLayer.Canvas.extend({
     // tiles currently in the viewport
     this.activeTiles = {};
 
-    // thats that have been loaded and drawn
-    this.loadedTiles = {};
-
     this._url = this.options.url;
 
     /**
@@ -211,7 +208,6 @@ module.exports = L.TileLayer.MVTSource = L.TileLayer.Canvas.extend({
           return;
         }
         self.checkVectorTileLayers(parseVT(vt), ctx);
-        tileLoaded(self, ctx);
       }
 
       //either way, reduce the count of tilesToProcess tiles here
@@ -493,10 +489,6 @@ function getTileURL(lat, lon, zoom) {
   var xtile = parseInt(Math.floor( (lon + 180) / 360 * (1<<zoom) ));
   var ytile = parseInt(Math.floor( (1 - Math.log(Math.tan(lat.toRad()) + 1 / Math.cos(lat.toRad())) / Math.PI) / 2 * (1<<zoom) ));
   return "" + zoom + ":" + xtile + ":" + ytile;
-}
-
-function tileLoaded(pbfSource, ctx) {
-  pbfSource.loadedTiles[ctx.id] = ctx;
 }
 
 function parseVT(vt){

--- a/src/MVTSource.js
+++ b/src/MVTSource.js
@@ -125,6 +125,7 @@ module.exports = L.TileLayer.MVTSource = L.TileLayer.Canvas.extend({
     this.removeChildLayers(map);
     map.off('click', this._onClick, this);
     L.TileLayer.Canvas.prototype.onRemove.call(this, map);
+    this.map = null;
   },
 
   drawTile: function(canvas, tilePoint, zoom) {

--- a/src/StaticLabel/StaticLabel.js
+++ b/src/StaticLabel/StaticLabel.js
@@ -38,16 +38,9 @@ function init(self, mvtFeature, ctx, latLng, style) {
     self.marker._icon.classList.add(self.style.cssSelectedClass || 'label-icon-text-selected');
   }
 
-  self.marker.on('click', function(e) {
-    self.toggle();
-  });
+  self.marker.on('click', self.toggle, self);
 
-  self.map.on('zoomend', function(e) {
-    var newZoom = e.target.getZoom();
-    if (self.zoom !== newZoom) {
-      self.map.removeLayer(self.marker);
-    }
-  });
+  self.map.on('zoomend', this._onZoomEnd, this);
 }
 
 
@@ -75,5 +68,13 @@ StaticLabel.prototype.deselect = function() {
 
 StaticLabel.prototype.remove = function() {
   if (!this.map || !this.marker) return;
+  this.map.off('zoomend', this._onZoomEnd, this);
   this.map.removeLayer(this.marker);
 };
+
+StaticLabel.prototype._onZoomEnd = function() {
+  var newZoom = e.target.getZoom();
+  if (this.zoom !== newZoom) {
+    this.remove();
+  }
+}


### PR DESCRIPTION
Some zoomend listeners attached to global map
were not being properly cleaned up when the vector layer
is removed.  If the layer is being added and removed
multiple times (or even if the user zooms repeatedly),
the layer features will leak and at high scale,
the browser OOMs.  Added some more eventing propagation
on layer removal to handle this case.