### PR TITLE
Add multiple draw passes for hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   },
   "homepage": "https://github.com/SpatialServer/Leaflet.MapboxVectorTile",
   "dependencies": {
-    "vector-tile": "~0.1.2",
     "pbf": "0.0.2",
     "point-geometry": "0.0.0",
-    "request": "~2.44.0"
+    "rbush": "^1.4.0",
+    "request": "~2.44.0",
+    "vector-tile": "~0.1.2"
   },
   "devDependencies": {
     "browserify": "~5.9.1",

--- a/src/MVTFeature.js
+++ b/src/MVTFeature.js
@@ -156,8 +156,12 @@ MVTFeature.prototype.draw = function(canvasID) {
 };
 
 MVTFeature.prototype.getPathsForTile = function(canvasID) {
-  //Get the info from the parts list
-  return this.tiles[canvasID].paths;
+  var tile = this.tiles[canvasID];
+  if (tile) {
+    return tile.paths;
+  } else {
+    return [];
+  }
 };
 
 MVTFeature.prototype.addTileFeature = function(vtf, ctx) {

--- a/src/MVTFeature.js
+++ b/src/MVTFeature.js
@@ -87,7 +87,7 @@ function ajaxCallback(self, response) {
   }
 
   self._setStyle(self.mvtLayer.style);
-  redrawTiles(self);
+  this.redraw();
 }
 
 MVTFeature.prototype._setStyle = function(styleFn) {
@@ -195,20 +195,15 @@ MVTFeature.prototype.clearTileFeatures = function(zoom) {
 /**
  * Redraws all of the tiles associated with a feature. Useful for
  * style change and toggling.
- *
- * @param self
  */
-function redrawTiles(self) {
+MVTFeature.prototype.redraw = function() {
   //Redraw the whole tile, not just this vtf
-  var tiles = self.tiles;
-  var mvtLayer = self.mvtLayer;
-
-  for (var id in tiles) {
+  for (var id in this.tiles) {
     var tileZoom = parseInt(id.split(':')[0]);
-    var mapZoom = self.map.getZoom();
+    var mapZoom = this.map.getZoom();
     if (tileZoom === mapZoom) {
       //Redraw the tile
-      mvtLayer.redrawTile(id);
+      this.mvtLayer.redrawTile(id);
     }
   }
 }
@@ -224,7 +219,7 @@ MVTFeature.prototype.toggle = function() {
 MVTFeature.prototype.select = function() {
   this.selected = true;
   this.mvtSource.featureSelected(this);
-  redrawTiles(this);
+  this.redraw();
   var linkedFeature = this.linkedFeature();
   if (linkedFeature && linkedFeature.staticLabel && !linkedFeature.staticLabel.selected) {
     linkedFeature.staticLabel.select();
@@ -234,7 +229,7 @@ MVTFeature.prototype.select = function() {
 MVTFeature.prototype.deselect = function() {
   this.selected = false;
   this.mvtSource.featureDeselected(this);
-  redrawTiles(this);
+  this.redraw();
   var linkedFeature = this.linkedFeature();
   if (linkedFeature && linkedFeature.staticLabel && linkedFeature.staticLabel.selected) {
     linkedFeature.staticLabel.deselect();


### PR DESCRIPTION
Modify visibleLayers to allow for mapping.

* visibleLayers can now be specified as a { [string]: string } map.
      This allows specification of multiple, differently-styled render
      passes based on the same layer data.  Is particularly useful for
      rendering overlay-style interactive elements (like hover).
* Empty visibleLayers array now means no layers, instead of all layers
      shown.  Slightly API-breaking, though this seems like the more
      consistent value (probably better to treat absent/null as
      the special "show all" value, rather than empty array, which
      logically seems more like "show none".
* Also exposed `MVTFeature.redraw` method, to allow individual features
     to be restyled rapidly during hover interaction without redrawing
     the whole layer (or using a double `.toggle()` hack).
