### PR TITLE
add license title; use standard licence text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
+ISC License
+
 Copyright (c) 2014, Spatial Development International
-All rights reserved.
 
 Source code can be found at:
 https://github.com/SpatialServer/Leaflet.MapboxVectorTile


### PR DESCRIPTION
The title is not strictly required, but it's useful metadata, and part of the recommended license template text:

- http://choosealicense.com/licenses/isc/
- https://opensource.org/licenses/isc-license
- http://spdx.org/licenses/ISC.html#licenseText