### PR TITLE
uniqueID should default to Util.getIDForLayerFeature

### DIFF
--- a/src/MVTLayer.js
+++ b/src/MVTLayer.js
@@ -184,7 +184,7 @@ module.exports = L.TileLayer.Canvas.extend({
       } else {
         getIDForLayerFeature = Util.getIDForLayerFeature;
       }
-      var uniqueID = self.options.getIDForLayerFeature(vtf) || i;
+      var uniqueID = getIDForLayerFeature(vtf) || i;
       var mvtFeature = self.features[uniqueID];
 
       /**


### PR DESCRIPTION
There's an if/else statement to figure out what function to use for getIDForLayerFeature, but then it is not used!
