### PR TITLE
setStyle should extend this.style

### DIFF
--- a/src/MVTFeature.js
+++ b/src/MVTFeature.js
@@ -100,7 +100,8 @@ MVTFeature.prototype._setStyle = function(styleFn) {
 
 MVTFeature.prototype.setStyle = function(styleFn) {
   this.ajaxData = null;
-  this.style = styleFn(this, null);
+  // update or create new style object
+  this.style = L.Util.extend({}, this.style, styleFn(this, null));
   var hasAjaxSource = ajax(this);
   if (!hasAjaxSource) {
     // The label gets removed, and the (re)draw,


### PR DESCRIPTION
Trying to make it more similar to [Leaflet Vector setStyle](https://github.com/Leaflet/Leaflet/blob/master/src/layer/vector/Path.js#L101): note that it uses `L.Util.setOptions` to extend `this.options`.  I think it would be helpful to match expected outputs.