### PR TITLE
Add fillOpacity and opacity to style atts

### DIFF
--- a/src/MVTFeature.js
+++ b/src/MVTFeature.js
@@ -357,10 +357,10 @@ MVTFeature.prototype._drawPolygon = function(ctx, coordsArray, style) {
   }
 
   ctx2d.closePath();
-  ctx2d.globalAlpha = style.fillOpacity || 1;
+  ctx2d.globalAlpha = (style.fillOpacity === undefined) ? 1 : style.fillOpacity;
   ctx2d.fill();
   if (outline && outline.size !== 0) {
-    ctx2d.globalAlpha = style.opacity || 1;
+    ctx2d.globalAlpha = (style.opacity === undefined) ? 1 : style.opacity;
     ctx2d.stroke();
   }
 

--- a/src/MVTFeature.js
+++ b/src/MVTFeature.js
@@ -357,8 +357,10 @@ MVTFeature.prototype._drawPolygon = function(ctx, coordsArray, style) {
   }
 
   ctx2d.closePath();
+  ctx2d.globalAlpha = style.fillOpacity || 1;
   ctx2d.fill();
-  if (outline) {
+  if (outline && outline.size !== 0) {
+    ctx2d.globalAlpha = style.opacity || 1;
     ctx2d.stroke();
   }
 


### PR DESCRIPTION
Following the conventions of Leaflet path drawing on canvas: https://github.com/Leaflet/Leaflet/blob/master/src/layer/vector/Canvas.js#L322